### PR TITLE
Add comments to pharmacy group tests

### DIFF
--- a/tests/test_pharmacy_groups.py
+++ b/tests/test_pharmacy_groups.py
@@ -1,3 +1,5 @@
+# This module contains tests for managing pharmacy groups.
+# The scenarios cover creation, deletion and editing of groups.
 import time
 import pytest
 import allure
@@ -9,6 +11,7 @@ from pages.pharmacy_group_page import PharmacyGroupPage
 @allure.suite("Management tests")
 @allure.feature("Pharmacy groups")
 @allure.title("User can't Delete Default pharmacy group")
+# Ensure the default group cannot be deleted.
 def test_cannot_delete_default_group(driver, login):
     # Open Pharmacy Groups section
     base = BasePage(login.driver)
@@ -21,6 +24,7 @@ def test_cannot_delete_default_group(driver, login):
 
 
 @allure.title("Change default group")
+# Switch the default pharmacy group and restore the original default.
 def test_change_default_pharmacy_group(driver, login):
     base = BasePage(login.driver)
     base.open("pharmacyGroups")
@@ -47,6 +51,7 @@ def test_change_default_pharmacy_group(driver, login):
 
 
 @allure.title("Delete pharmacy group")
+# Create a new group and verify it can be deleted.
 def test_delete_pharmacy_group(driver, login):
     base = BasePage(login.driver)
     base.open("pharmacyGroups")
@@ -64,6 +69,7 @@ def test_delete_pharmacy_group(driver, login):
 
 
 @allure.title("Group becomes default after deleting current group")
+# After deleting the only pharmacy the group becomes default.
 def test_group_becomes_default_after_deletion(driver, login):
     base = BasePage(login.driver)
     base.open("pharmacyGroups")
@@ -89,6 +95,7 @@ def test_group_becomes_default_after_deletion(driver, login):
 
 
 @allure.title("Search for pharmacy group")
+# Search for a pharmacy group and remove the results.
 def test_search_pharmacy_group(driver, login):
     base = BasePage(login.driver)
     base.open("pharmacyGroups")
@@ -115,6 +122,7 @@ def test_search_pharmacy_group(driver, login):
 
 
 @allure.title("Create pharmacy group")
+# Verify creation of a new pharmacy group.
 def test_create_pharmacy_group(driver, login):
     base = BasePage(login.driver)
     base.open("pharmacyGroups")
@@ -133,6 +141,7 @@ def test_create_pharmacy_group(driver, login):
 
 
 @allure.title("Change Pharmacy Group for pharmacy")
+# Move a pharmacy from one group to another and verify the change.
 def test_change_group_for_pharmacy(driver, login):
     base = BasePage(login.driver)
     base.open("pharmacyGroups")
@@ -166,6 +175,7 @@ def test_change_group_for_pharmacy(driver, login):
 
 
 @allure.title("Delete pharmacy from group")
+# Remove a pharmacy from a group and confirm notification.
 def test_delete_pharmacy_from_group(driver, login):
     base = BasePage(login.driver)
     base.open("pharmacyGroups")
@@ -186,6 +196,7 @@ def test_delete_pharmacy_from_group(driver, login):
 
 
 @allure.title("Edit pharmacy group")
+# Edit an existing pharmacy group by adding a new pharmacy.
 def test_edit_pharmacy_group(driver, login):
     base = BasePage(login.driver)
     base.open("pharmacyGroups")
@@ -212,6 +223,7 @@ def test_edit_pharmacy_group(driver, login):
 
 
 @allure.title("Create default pharmacy group and link pharmacy")
+# Create a new default group and link a pharmacy to it.
 def test_create_default_pharmacy_group(driver, login):
     base = BasePage(login.driver)
     base.open("pharmacyGroups")


### PR DESCRIPTION
## Summary
- add module-level comment and explanatory comments for each pharmacy group test

## Testing
- `python -m py_compile tests/test_pharmacy_groups.py`

------
https://chatgpt.com/codex/tasks/task_e_685ea85740508327977038a43fea77d5